### PR TITLE
fix: Remove unsupported version querystring param

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -110,7 +110,6 @@
 | Name     | Value     | Kind     | Required?     | Notes     |
 |------    |-------    |------    |-----------    |-------    |
 | package | String | **Path**  | ✅         | the name of the package |
-| version | String | **Query** | ❌         | a version number        |
 
 This endpoint responds with the package metadata document, sometimes informally called a "packument" or "doc.json". The format of the response is described in detail in the [package metadata documentation](responses/package-metadata.md).
 


### PR DESCRIPTION
The `version` query string parameter is not supported and should be removed from the API documentation.