### PR TITLE
document per version download counts api

### DIFF
--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -134,7 +134,7 @@ All other queries are limited to at most *18 months* of data. The earliest date 
 
 ## Per version download counts
 
-Gets the downloads for the last 7 days per version of a specific package.
+Download count for specific versions of a package are only available for the previous 7 days. They have a unique API end point
 
 <code>GET https://api.npmjs.org/versions/{package}/last-week</code>
 
@@ -143,4 +143,4 @@ Note: for scoped packages, the `/` needs to be percent encoded. (`@slack/client`
 ### Examples
 
 <a href="https://api.npmjs.org/versions/fastify/last-week">/versions/fastify/last-week</a>  
-<a href="https://api.npmjs.org/versions/@slack%2Fclient/last-week">/versions/@slack%2Fclient/last-week</a>  
+<a href="https://api.npmjs.org/versions/@slack%2Fclient/last-week">/versions/@slack%2Fclient/last-week</a>

--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -138,6 +138,9 @@ Gets the downloads for the last 7 days per version of a specific package.
 
 <code>GET https://api.npmjs.org/versions/{package}/last-week</code>
 
-### Example
+Note: for scoped packages, the `/` needs to be percent encoded. (`@slack/client` -> `@slack%2Fclient`).
 
-<a href="https://api.npmjs.org/versions/fastify/last-week">/versions/fastify/last-week</a>
+### Examples
+
+<a href="https://api.npmjs.org/versions/fastify/last-week">/versions/fastify/last-week</a>  
+<a href="https://api.npmjs.org/versions/@slack%2Fclient/last-week">/versions/@slack%2Fclient/last-week</a>  

--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -130,3 +130,14 @@ __Important:__ As of this writing, 19 April 2017, *scoped* packages are not yet 
 Bulk queries are limited to at most *128* packages at a time and at most *365 days* of data.
 
 All other queries are limited to at most *18 months* of data. The earliest date for which data will be returned is January 10, 2015.
+
+
+## Per version download counts
+
+Gets the downloads for the last 7 days per version of a specific package.
+
+<code>GET https://api.npmjs.org/versions/{package}/last-week</code>
+
+### Example
+
+<a href="https://api.npmjs.org/versions/fastify/last-week">/versions/fastify/last-week</a>


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

It was announced here https://github.blog/changelog/2021-01-27-npmjs-com-displays-per-version-download-counts/

But it's not documented anywhere I think? 