### PR TITLE
update scoped packages in bulk queries status info

### DIFF
--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -123,7 +123,7 @@ separated list of packages rather than a single package, e.g.,
 
 `/downloads/point/last-day/npm,express`
 
-__Important:__ As of this writing, 19 April 2017, *scoped* packages are not yet supported in bulk queries. So you cannot request `/downloads/point/last-day/@slack/client,@iterables/map` yet. We *do* plan to support scoped modules in bulk queries as soon as we can make bulk auth checks efficiently. The latter work is in progress.
+__Important:__ *Scoped* packages are not yet supported in bulk queries. So you cannot request `/downloads/point/last-day/@slack/client,@iterables/map` yet. We *do* plan to support scoped modules in bulk queries as soon as we can make bulk auth checks efficiently. The latter work is in progress.
 
 ## Limits
 

--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -123,7 +123,7 @@ separated list of packages rather than a single package, e.g.,
 
 `/downloads/point/last-day/npm,express`
 
-__Important:__ *Scoped* packages are not yet supported in bulk queries. So you cannot request `/downloads/point/last-day/@slack/client,@iterables/map` yet. We *do* plan to support scoped modules in bulk queries as soon as we can make bulk auth checks efficiently. The latter work is in progress.
+__Important:__ *Scoped* packages are not yet supported in bulk queries. So you cannot request `/downloads/point/last-day/@slack/client,@iterables/map` yet.
 
 ## Limits
 


### PR DESCRIPTION
This is a small change, which removes the date from note about status of scoped packages in bulk queries. 

It looks like this feature have not been implemented yet, and such distant in time date does not look particular good.

<img width="556" alt="Screenshot 2021-03-06 222801" src="https://user-images.githubusercontent.com/719641/110221221-3fdf6d00-7ecb-11eb-82b3-18e4471b047c.png">

PS. Are there any news if, or when, this feature will be implemented? 🙂 

## References

No.
