### PR TITLE
chore(docs): remove empty endpoint

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -98,11 +98,6 @@
 }
 ```
 
-#### `GET·/-/all`
-
-| Name     | Value     | Kind     | Required?     | Notes     |
-|------    |-------    |------    |-----------    |-------    |
-
 ### Package Endpoints
 
 #### `GET·/{package}`


### PR DESCRIPTION
This endpoint returns empty (intentionally, I assume) and should be removed from the docs as it does not provide any value.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
```
> https://registry.npmjs.org/-/all
< []
```
