### PR TITLE
Update package-metadata.md

### DIFF
--- a/docs/responses/package-metadata.md
+++ b/docs/responses/package-metadata.md
@@ -213,6 +213,7 @@ Each abbreviated version object contains the following fields:
 * `devDependencies`: a mapping of package names to the required semver ranges of _development_ dependencies
 * `bundleDependencies`: an array of dependencies bundled with this version
 * `peerDependencies`: a mapping of package names to the required semver ranges of _peer_ dependencies
+* `peerDependenciesMeta`: provide npm more information on how your peer dependencies are to be used.
 * `bin`: a mapping of bin commands to set up for this version
 * `directories`: an array of directories included by this version
 * `dist`: a [dist object](#dist)
@@ -248,7 +249,7 @@ The following fields are hoisted to the top-level of the package json from the l
 * `readmeFilename`: The name of the file from which the readme data was taken.
 * `repository`: as given in package.json, for the latest version
 
-Each package version data object contains all of the fields in the abbreviated document, plus the fields listed above as hosted, plus at least the following:
+Each package version data object contains all of the fields in the abbreviated document, except `hasInstallScript`, plus the fields listed above as hosted, plus at least the following:
 
 * `_id`: `package@version`, such as `npm@1.0.0`
 * `_nodeVersion`: the version of node used to publish this


### PR DESCRIPTION
Align spec to usage, based on https://registry.npmjs.org:
- hasInstallScript is not returned in the full package version metadata
- peerDependenciesMeta is returned in the abbreviated package version metadata

examples:
if `npm install pg` will be used without `peerDependenciesMeta`, it will fail unless postgres is locally installed. on npmjs it's returned in the abbreviated response.
`hasInstallScript` is not returned in the full metadata, but `scripts` is returned instead. if scripts contains install, preinstall or postinstall, it will transform to this. (based on https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json)


<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
