### PR TITLE
Clarify hasInstallScript

### DIFF
--- a/docs/responses/package-metadata.md
+++ b/docs/responses/package-metadata.md
@@ -218,7 +218,7 @@ Each abbreviated version object contains the following fields:
 * `dist`: a [dist object](#dist)
 * `engines`: the node engines required for this version to run, if specified
 * `_hasShrinkwrap`: `true` if this version is known to have a shrinkwrap that must be used to install it; `false` if this version is known not to have a shrinkwrap. If this field is undefined, the client must determine through other means if a shrinkwrap exists.
-* `hasInstallScript`: `true` if this version has the `install, preinstall, or postinstall` script.
+* `hasInstallScript`: `true` if this version has the `install`, `preinstall`, or `postinstall` scripts.
 
 The `name`, `version`, and `dist` fields will always be present. The others will be absent if they are irrelevant for this package version.
 

--- a/docs/responses/package-metadata.md
+++ b/docs/responses/package-metadata.md
@@ -218,7 +218,7 @@ Each abbreviated version object contains the following fields:
 * `dist`: a [dist object](#dist)
 * `engines`: the node engines required for this version to run, if specified
 * `_hasShrinkwrap`: `true` if this version is known to have a shrinkwrap that must be used to install it; `false` if this version is known not to have a shrinkwrap. If this field is undefined, the client must determine through other means if a shrinkwrap exists.
-* `hasInstallScript`: `true` if this version has the `install` scripts.
+* `hasInstallScript`: `true` if this version has the `install, preinstall, or postinstall` script.
 
 The `name`, `version`, and `dist` fields will always be present. The others will be absent if they are irrelevant for this package version.
 


### PR DESCRIPTION
Clarify `hasInstallScript` should match on the following scripts fields:
https://github.com/npm/cli/blob/b3977743be36b49f43c13cf116044731ed16d960/workspaces/arborist/lib/node.js#L317