### PR TITLE
Add missing acceptedDependences to abbreviated metadata

### DIFF
--- a/docs/responses/package-metadata.md
+++ b/docs/responses/package-metadata.md
@@ -209,6 +209,7 @@ Each abbreviated version object contains the following fields:
 * `version`: the version string for this version
 * `deprecated`: the deprecation warnings message of this version
 * `dependencies`: a mapping of other packages this version depends on to the required semver ranges
+* `acceptDependencies`: a mapping of packages to alternative versions that can be used
 * `optionalDependencies`:  an object mapping package names to the required semver ranges of _optional_ dependencies
 * `devDependencies`: a mapping of package names to the required semver ranges of _development_ dependencies
 * `bundleDependencies`: an array of dependencies bundled with this version

--- a/docs/responses/package-metadata.md
+++ b/docs/responses/package-metadata.md
@@ -221,6 +221,7 @@ Each abbreviated version object contains the following fields:
 * `engines`: the node engines required for this version to run, if specified
 * `_hasShrinkwrap`: `true` if this version is known to have a shrinkwrap that must be used to install it; `false` if this version is known not to have a shrinkwrap. If this field is undefined, the client must determine through other means if a shrinkwrap exists.
 * `hasInstallScript`: `true` if this version has the `install` scripts.
+* `funding`: object containing a URL that provides up-to-date information about ways to help fund development of your package, or a string URL, or an array of these
 * `cpu`: an array of CPU architectures supported by the package
 * `os`: an array of operating systems supported by the package
 


### PR DESCRIPTION
`acceptDependencies` is returned from NPM abbreviated metadata, but is not from other repositories, specifically `artifactory` - leading to dependency installation issues. 

I assume this is partially due at least to it not being documented here. 


Edit: Also added `funding` as i found what i believe to be the source in the [code](https://github.com/npm/minify-registry-metadata/blob/e8cdb14d59ef7c3984bccb4da1557daa09f8f0e8/lib/index.js#L9C1-L28C2) and it contained funding but this did not. Please let me know if this is not the source of truth 