### PR TITLE
docs: mention https://registry.npmjs.org in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # :package: npm registry documentation
 
-A collection of archived documentation about registry endpoints/API
+A collection of archived documentation about registry endpoints/API.
+
+See the registry at https://registry.npmjs.org.
 
 If you're having issues with the website or registry itself please 
 [contact npm's support staff](https://www.npmjs.com/support).


### PR DESCRIPTION
This was a confusion point when I tried to get started using the API. I couldn't easily find a place that explicitly said where the API is called from / the base URL is!

I would have filed an issue, but issues are disabled 🙂. 

Aside: amusing that the commit is listed as _Unverified_. I authored it through the GitHub web UI.