### PR TITLE
Add undocumented `last-year` flag to download-counts docs

### DIFF
--- a/docs/download-counts.md
+++ b/docs/download-counts.md
@@ -51,6 +51,8 @@ Acceptable values are:
 	<dd>Gets downloads for the last 7 available days.</dd>
   	<dt>last-month</dt>
 	<dd>Gets downloads for the last 30 available days.</dd>
+	<dt>last-year</dt>
+	<dd>Gets downloads for the last 365 available days.</dd>
 </dl>
 
 ### Output


### PR DESCRIPTION
The documentation for download-counts shows examples of named ranges, like `last-day` or `last-month`, but didn't list the available `list-year` flag, which seems to exist and work as expected: https://api.npmjs.org/downloads/range/last-year/