### PR TITLE
Update README.md with new registry URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collection of archived documentation about registry endpoints/API.
 
-See the registry at https://registry.npmjs.org.
+See the registry at https://replicate.npmjs.com.
 
 If you're having issues with the website or registry itself please 
 [contact npm's support staff](https://www.npmjs.com/support).


### PR DESCRIPTION
When navigating to registry.npmjs.org, the response content is empty, and the response headers contain an Npm-Notice: "This endpoint is deprecated. Use https://replicate.npmjs.com instead."  This PR replaces the deprecated endpoint with the endpoint suggested in the response header.

![Screenshot 2024-05-24 112739 box](https://github.com/npm/registry/assets/2312651/029e6902-f36b-4699-b4c8-b13f0ab3020a)


