### PR TITLE
docs: mention duplicated packages in search results

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -127,7 +127,7 @@ This endpoint responds with the package metadata document, sometimes informally 
 | maintenance | float | **Query** | ❌         | how much of an effect should maintenance have on search results |
 
 _Note: the values of `quality`, `popularity`, and `maintenance` are normalized into a unit-vector provide values between `0 - 1` for each to modify weightings, e.g., to return
- results based solely on `quality`, set `quality=1.0`, `maintenance=0.0`, `popularity=0.0`._
+ results based solely on `quality`, set `quality=1.0`, `maintenance=0.0`, `popularity=0.0`. Also, at larger values of `from`, search results may start duplicating._
 
 **response format:**
 


### PR DESCRIPTION
In bigger values of `from`, sometimes, the NPM packages begin duplicating. This documents that.