### PR TITLE
chore(docs): update registry API table of contents

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -11,8 +11,6 @@
 - [Endpoints](#endpoints)
   - [Meta Endpoints](#meta-endpoints)
     - [`GET·/`](#get)
-    - [`GET·/-/all`](#get-all)
-    - [`GET·/-/`]
   - [Package Endpoints](#package-endpoints)
     - [`GET·/{package}`](#getpackage)
     - [`GET·/{package}/{version}`](#getpackageversion)


### PR DESCRIPTION
The table of contents hadn't been updated to match the rest of the docs, leading to broken links and non-existent API endpoints being advertised.