### PR TITLE
Update time format in REGISTRY-API.md search endpoint response

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -190,7 +190,7 @@ _Note: the values of `quality`, `popularity`, and `maintenance` are normalized i
     }
   ],
   "total": 1,
-  "time": "Wed Jan 25 2017 19:23:35 GMT+0000 (UTC)"
+  "time": "2017-01-25T19:23:35.000Z"
 }
 ```
 


### PR DESCRIPTION
- Replace JavaScript date format (i.e. output of new Date().toString()) with ISO 8601 date string in the example response for the search endpoint in REGISTRY-API.md

<!-- What / Why -->

<!-- Describe the request in detail. What it does and why it's being changed. -->

It seems that the format used for the "time" key in the NPM registry search endpoint is ISO 8601. You can check this by running: 

```
curl -get "https://registry.npmjs.com/-/v1/search?text=is-odd&size=1"
```

which provides the following output:
```json
{"objects":[],"total":1035806,"time":"2026-01-18T05:50:08.363Z"}
```
